### PR TITLE
Fixed a typo in the tab include

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Inside the `<!-- Tab Panels -->` section, place the code to load the notificatio
 
 ```html
 <div role="tabpanel" class="tab-pane" id="notifications">
-    @include('spark-notify::notifications')
+    @include('spark-kiosk-notify::notifications')
 </div>
 ```
 


### PR DESCRIPTION
The include path is incorrectly pointing at `spark-notify` however should be `spark-kiosk-notify` to work.
